### PR TITLE
🚀 [Feat]: 버튼 컴포넌트 

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,10 +7,13 @@ const config: Config = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
-  globals: {
-    "ts-jest": {
-      tsconfig: "tsconfig.jest.json",
-    },
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: "tsconfig.jest.json",
+      },
+    ],
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
 };

--- a/src/__tests__/unit/components/button.test.tsx
+++ b/src/__tests__/unit/components/button.test.tsx
@@ -1,0 +1,51 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+import Button from "../../../components/Button/Button";
+
+describe("Button 컴포넌트 테스트", () => {
+  it("버튼 렌더링 확인", () => {
+    render(<Button>button</Button>);
+    const button = screen.getByText("button");
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it("버튼 텍스트 확인", () => {
+    render(<Button>button</Button>);
+    const button = screen.getByText("button");
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it("버튼 클릭 이벤트 확인", () => {
+    let count = 0;
+    const handleClick = jest.fn(() => {
+      count += 1;
+    });
+    render(<Button onClick={handleClick}>button</Button>);
+    const button = screen.getByText("button");
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(count).toBe(1);
+  });
+
+  it("버튼 비활성화 확인", () => {
+    let count = 0;
+    const handleClick = jest.fn(() => {
+      count += 1;
+    });
+    render(
+      <Button variant="disabled" onClick={handleClick}>
+        button
+      </Button>,
+    );
+    const button = screen.getByText("button");
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(0);
+    expect(count).toBe(0);
+  });
+});

--- a/src/components/Button/Button.stories.ts
+++ b/src/components/Button/Button.stories.ts
@@ -24,7 +24,7 @@ export default meta;
 
 export const Default: StoryObj<ButtonProps> = {
   args: {
-    children: "button",
+    children: "default button",
   },
 };
 

--- a/src/components/Button/Button.stories.ts
+++ b/src/components/Button/Button.stories.ts
@@ -1,0 +1,125 @@
+import Button, { ButtonProps } from "@/components/Button/Button";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Button> = {
+  title: "Components/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["fill", "outline", "ghost", "disabled"],
+    },
+    size: {
+      control: "select",
+      options: ["small", "medium", "large"],
+    },
+  },
+};
+
+export default meta;
+
+export const Default: StoryObj<ButtonProps> = {
+  args: {
+    children: "button",
+  },
+};
+
+export const FillSmall: StoryObj<ButtonProps> = {
+  args: {
+    variant: "fill",
+    size: "small",
+    children: "button",
+  },
+};
+
+export const FillMedium: StoryObj<ButtonProps> = {
+  args: {
+    variant: "fill",
+    size: "medium",
+    children: "button",
+  },
+};
+
+export const FillLarge: StoryObj<ButtonProps> = {
+  args: {
+    variant: "fill",
+    size: "large",
+    children: "button",
+  },
+};
+
+export const OutlineSmall: StoryObj<ButtonProps> = {
+  args: {
+    variant: "outline",
+    size: "small",
+    children: "button",
+  },
+};
+
+export const OutlineMedium: StoryObj<ButtonProps> = {
+  args: {
+    variant: "outline",
+    size: "medium",
+    children: "button",
+  },
+};
+
+export const OutlineLarge: StoryObj<ButtonProps> = {
+  args: {
+    variant: "outline",
+    size: "large",
+    children: "button",
+  },
+};
+
+export const GhostSmall: StoryObj<ButtonProps> = {
+  args: {
+    variant: "ghost",
+    size: "small",
+    children: "button",
+  },
+};
+
+export const GhostMedium: StoryObj<ButtonProps> = {
+  args: {
+    variant: "ghost",
+    size: "medium",
+    children: "button",
+  },
+};
+
+export const GhostLarge: StoryObj<ButtonProps> = {
+  args: {
+    variant: "ghost",
+    size: "large",
+    children: "button",
+  },
+};
+
+export const DisabledSmall: StoryObj<ButtonProps> = {
+  args: {
+    variant: "disabled",
+    size: "small",
+    children: "button",
+  },
+};
+
+export const DisabledMedium: StoryObj<ButtonProps> = {
+  args: {
+    variant: "disabled",
+    size: "medium",
+    children: "button",
+  },
+};
+
+export const DisabledLarge: StoryObj<ButtonProps> = {
+  args: {
+    variant: "disabled",
+    size: "large",
+    children: "button",
+  },
+};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,7 +2,7 @@ import { buttonStyles } from "@/components/Button/buttonVariants";
 import { cn } from "@/utils/className";
 import { VariantProps } from "class-variance-authority";
 
-interface ButtonProps
+export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonStyles> {
   children?: React.ReactNode;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,17 @@
-function Button() {
-  return <div>버튼 컴포넌트</div>;
+import { buttonStyles } from "@/components/Button/buttonVariants";
+import { cn } from "@/utils/className";
+import { VariantProps } from "class-variance-authority";
+
+interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonStyles> {
+  children?: React.ReactNode;
 }
+
+const Button = ({ className, variant, size, ...props }: ButtonProps) => {
+  const buttonClass = cn(className, buttonStyles({ variant: variant, size: size }));
+
+  return <button className={buttonClass} disabled={variant === "disabled"} {...props} />;
+};
 
 export default Button;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { buttonStyles } from "@/components/Button/buttonVariants";
+import { buttonStyles } from "@/components/Button/ButtonVariants";
 import { cn } from "@/utils/className";
 import { VariantProps } from "class-variance-authority";
 

--- a/src/components/Button/ButtonVariants.ts
+++ b/src/components/Button/ButtonVariants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonStyles = cva(
-  "h-[40px] rounded-[5px] flex justify-center items-center text-base font-medium transition-color px-[8px] duration-300 ease-in-out",
+  "h-10 rounded-[5px] flex justify-center items-center text-base font-medium transition-color px-2 duration-300 ease-in-out",
   {
     variants: {
       variant: {

--- a/src/components/Button/ButtonVariants.ts
+++ b/src/components/Button/ButtonVariants.ts
@@ -1,0 +1,25 @@
+import { cva } from "class-variance-authority";
+
+export const buttonStyles = cva(
+  "w-full max-h-[40px] rounded-[5px] flex justify-center items-center py-[8px] text-base font-medium transition-color duration-300 ease-in-out",
+  {
+    variants: {
+      variant: {
+        fill: "bg-primary-500 text-white hover:bg-primary-500/80 active:bg-accent-100",
+        outline:
+          "bg-white border-2 border-primary-500 text-primary-400 hover:border-primary-300 active:border-accent-100 active:text-accent-100",
+        ghost: "bg-neutral-400/40 text-primary-400 hover:bg-neutral-400/70 active:text-accent-100",
+        disabled: "bg-neutral-400 text-neutral-700 cursor-not-allowed",
+      },
+      size: {
+        small: "w-[67px] h-[27px]",
+        medium: "w-[120px] h-[40px]",
+        large: "w-[160px] h-[40px]",
+      },
+    },
+    defaultVariants: {
+      variant: "fill",
+      size: "medium",
+    },
+  },
+);

--- a/src/components/Button/ButtonVariants.ts
+++ b/src/components/Button/ButtonVariants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonStyles = cva(
-  "w-full max-h-[40px] rounded-[5px] flex justify-center items-center py-[8px] text-base font-medium transition-color duration-300 ease-in-out",
+  "h-[40px] rounded-[5px] flex justify-center items-center text-base font-medium transition-color px-[8px] duration-300 ease-in-out",
   {
     variants: {
       variant: {
@@ -12,14 +12,15 @@ export const buttonStyles = cva(
         disabled: "bg-neutral-400 text-neutral-700 cursor-not-allowed",
       },
       size: {
-        small: "w-[67px] h-[27px]",
-        medium: "w-[120px] h-[40px]",
-        large: "w-[160px] h-[40px]",
+        default: "w-full",
+        small: "w-[67px]",
+        medium: "w-[120px]",
+        large: "w-[160px]",
       },
     },
     defaultVariants: {
       variant: "fill",
-      size: "medium",
+      size: "default",
     },
   },
 );


### PR DESCRIPTION
## #️⃣연관된 이슈

> MP-127-create-button

## 📝작업 내용

### 버튼 컴포넌트

버튼 컴포넌트에서 현재 `small`, `medium`, `large`로 되어있는데 각각의 `width`, `heigth`가 지정되어 있어서 버튼 안의 텍스트가 길어지거나 시스템에 맞지 않는 크기가 필요할때 수정이 필요할 것 같슴다

색상이 맞지 않는 부분이 있는데 비슷한 색으로 맞춰놨습니다.

### 버튼 컴포넌트 스토리북

가능한 상태를 모두 보여주고 있습니다.

### 버튼 컴포넌트 테스트

- 버튼 렌더링
- 버튼 텍스트
- 버튼 클릭
- 버튼 비활성화

### 스크린샷 (선택)

<img width="717" alt="image" src="https://github.com/user-attachments/assets/753cf284-0d8d-4d69-8b3f-d70dcd586ac1" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

131번 브랜치 머지 되면 리베이스 후 머지 하겠슴니당

추가로 스토리북 배포는 `Chromatic` 설치되어 있는데 자동으로 배포하는 방향으로 하는건 어떤가요?
